### PR TITLE
v3.9.34: migrate to WME SDK, fix sidebar layout, and other fixes

### DIFF
--- a/WME-URMP.user.js
+++ b/WME-URMP.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        WME UR-MP tracking
-// @version     3.9.31
+// @version     3.9.34
 // @description Track UR and MP in the Waze Map Editor
 // @namespace   https://greasyfork.org/en/scripts/368141-wme-ur-mp-tracking
 // @include     /^https:\/\/(www|beta)\.waze\.com\/(?!user\/)(.{2,6}\/)?editor\/?.*$/
@@ -196,7 +196,7 @@ function WMEURMPT_Injected () {
   const NL = "\n"
   const WMEURMPT = {}
   WMEURMPT.isDebug = false
-  WMEURMPT.urmpt_version = '3.9.31'
+  WMEURMPT.urmpt_version = '3.9.34'
   WMEURMPT.URList = []
   WMEURMPT.URBlacklist = []
   WMEURMPT.URMap = {}
@@ -282,6 +282,7 @@ function WMEURMPT_Injected () {
   WMEURMPT.PURCategoriesMaxLength = 9
   WMEURMPT.PURNameMaxLength = 12
   WMEURMPT.keepBlacklist = true
+  WMEURMPT.hideRank4Tip = false
   WMEURMPT.visitedURBeforeActionsSaved = []
   WMEURMPT.visitedMPBeforeActionsSaved = []
   WMEURMPT.visitedTPBeforeActionsSaved = []
@@ -572,34 +573,26 @@ function WMEURMPT_Injected () {
   }
 
   WMEURMPT.initializeWazeObjects = function () {
-    const objectToCheck = [
-      { o: 'W.map', s: 'wazeMap' },
-      { o: 'W.model', s: 'wazeModel' },
-      { o: 'W.loginManager', s: 'loginManager' },
-      { o: 'W.controller', s: 'wazeController' },
-      { o: 'W.Config.api_base', s: 'wazeConfigApiBase' },
-      { o: 'W.Config.paths.features', s: 'wazeConfigApiFeatures' },
-      { o: 'W.Config.paths.updateRequestSessions', s: 'wazeConfigApiUpdateRequestSessions' },
-      { o: 'W.loginManager.user', s: 'me' },
-      { o: 'W.loginManager.user.attributes.rank', s: 'ul' },
-      { o: 'W.loginManager.user.attributes.isAreaManager', s: 'uam' },
-      { o: 'W.problemsController', s: 'wazePC' },
-      { o: 'W.userscripts', s: 'wazeUS' }
-    ]
-    for (let i = 0; i < objectToCheck.length; i++) {
-      const path = objectToCheck[i].o.split('.')
-      let object = unsafeWindow
-      for (let j = 0; j < path.length; j++) {
-        object = object[path[j]]
-        if (typeof object === 'undefined' || object == null) {
-          window.setTimeout(WMEURMPT.initializeWazeObjects, 1000)
-          return
-        } else {
-          WMEURMPT[objectToCheck[i].s] = object
-        }
-      }
+    const W = unsafeWindow.W
+    if (!W || !W.map || !W.model || !W.loginManager) {
+      window.setTimeout(WMEURMPT.initializeWazeObjects, 500)
+      return
     }
-    WMEURMPT.ul = (WMEURMPT.ul + 1) * 2
+    // User rank and area-manager flag come from the SDK
+    const userInfo = wmeSDK.State.getUserInfo()
+    WMEURMPT.ul = userInfo ? (userInfo.rank + 1) * 2 : 2
+    WMEURMPT.uam = userInfo ? userInfo.isAreaManager : false
+    // W.* references kept for functionality not yet available in the SDK
+    WMEURMPT.wazeMap = W.map
+    WMEURMPT.wazeModel = W.model
+    WMEURMPT.loginManager = W.loginManager
+    WMEURMPT.me = W.loginManager.user
+    WMEURMPT.wazeController = W.controller
+    WMEURMPT.wazePC = W.problemsController
+    WMEURMPT.wazeUS = W.userscripts
+    WMEURMPT.wazeConfigApiBase = W.Config.api_base
+    WMEURMPT.wazeConfigApiFeatures = W.Config.paths.features
+    WMEURMPT.wazeConfigApiUpdateRequestSessions = W.Config.paths.updateRequestSessions
     WMEURMPT.initializeElements()
   }
 
@@ -703,6 +696,10 @@ function WMEURMPT_Injected () {
 
     wmeSDK.Events.stopDataModelEventsTracking({
       dataModelName: 'venues'
+    })
+
+    wmeSDK.Events.stopDataModelEventsTracking({
+      dataModelName: 'updateRequestSessions'
     })
 
     wmeSDK.Events.off({
@@ -824,11 +821,11 @@ function WMEURMPT_Injected () {
         filterArea = filterArea.concat( thisArea.geometryGeoJSON )
       }
       else if (typeof thisArea.geometryWKT !== 'undefined' && thisArea.geometryWKT !== null) {
-        filterArea = filterArea.concat( W.userscripts.convertWktToGeoJSON(thisArea.geometryWKT))
+        filterArea = filterArea.concat( WMEURMPT.wazeUS.convertWktToGeoJSON(thisArea.geometryWKT))
       }
       else if (typeof thisArea.geometryOL !== 'undefined' && thisArea.geometryOL !== null) {
-        filterArea = filterArea.concat(W.userscripts.toGeoJSONGeometry(thisArea.geometryOL))
-        WMEURMPT.areaList.country[i].geometryGeoJSON = W.userscripts.toGeoJSONGeometry(thisArea.geometryOL)
+        filterArea = filterArea.concat(WMEURMPT.wazeUS.toGeoJSONGeometry(thisArea.geometryOL))
+        WMEURMPT.areaList.country[i].geometryGeoJSON = WMEURMPT.wazeUS.toGeoJSONGeometry(thisArea.geometryOL)
       }
     }
 
@@ -927,7 +924,7 @@ function WMEURMPT_Injected () {
       return null
     }
     if (selObjs.objectType !== 'venue') {
-      WMEURMPT.log('error while getting selected PUR: ', e)
+      WMEURMPT.log('error while getting selected PUR: unexpected objectType ' + selObjs.objectType)
       return null
     }
     return selObjs.ids
@@ -1000,7 +997,7 @@ function WMEURMPT_Injected () {
               const userID = ur.data.session.comments[c].userID
               let userName = 'Unknown'
               if (userID === WMEURMPT.me.getID()) {
-                userName = WMEURMPT.me.getUsername()
+                userName = wmeSDK.State.getUserInfo().userName
                 if (c === ur.data.session.comments.length - 1) {
                   ur.lastVisitCommentsCount = ur.data.session.comments.length
                 }
@@ -1071,7 +1068,7 @@ function WMEURMPT_Injected () {
   }
 
   WMEURMPT.isURFiltered2 = function (ur) {
-    const userId = WMEURMPT.loginManager.user.getID()
+    const userId = WMEURMPT.me.getID()
     const userName = wmeSDK.State.getUserInfo().userName
     const Map_TeamUserId = 2218201706
     let found = false
@@ -1833,7 +1830,7 @@ function WMEURMPT_Injected () {
     ca.name = elName.value
     WMEURMPT.log('Add CA to scan list: ' + ca.name)
     ca.geometryWKT = WMEURMPT.lastUploadedWKT
-    ca.geometryGeoJSON = W.userscripts.convertWktToGeoJSON(WMEURMPT.lastUploadedWKT)
+    ca.geometryGeoJSON = WMEURMPT.wazeUS.convertWktToGeoJSON(WMEURMPT.lastUploadedWKT)
     WMEURMPT.removeCustomNameFromAreaList(ca.name)
     WMEURMPT.areaList.custom.push(ca)
     elName.value = ''
@@ -1980,12 +1977,12 @@ function WMEURMPT_Injected () {
           
         }
         else if (typeof area.geometryWKT !== 'undefined' && area.geometryWKT !== null) {
-          area.geometryGeoJSON = W.userscripts.convertWktToGeoJSON(area.geometryWKT)
+          area.geometryGeoJSON = WMEURMPT.wazeUS.convertWktToGeoJSON(area.geometryWKT)
           objArea = area.geometryGeoJSON
           center = turf.centroid(area.geometryGeoJSON)
         }
         else if (typeof area.geometryOL !== 'undefined' && area.geometryOL !== null) {
-          area.geometryGeoJSON = W.userscripts.toGeoJSONGeometry(area.geometryOL)
+          area.geometryGeoJSON = WMEURMPT.wazeUS.toGeoJSONGeometry(area.geometryOL)
           objArea = area.geometryGeoJSON
           center = turf.centroid(area.geometryGeoJSON)          
         }
@@ -2043,7 +2040,7 @@ function WMEURMPT_Injected () {
   }
 
   WMEURMPT.exportAllCAToJSON = function () {
-    this.setAttribute('download', 'URMPT_CustomAreas_' + WMEURMPT.me.getUsername() + '.json')
+    this.setAttribute('download', 'URMPT_CustomAreas_' + wmeSDK.State.getUserInfo().userName + '.json')
     this.href = 'data:application/octet-stream;charset=utf-8;base64,' + btoa(JSON.stringify(WMEURMPT.areaList.custom.map(function (e) {
       return { name: e.name, geometryWKT: e.geometryWKT , geometryGeoJSON: e.geometryGeoJSON }
     })))
@@ -2076,7 +2073,7 @@ function WMEURMPT_Injected () {
       elt.onclick = WMEURMPT.getFunctionWithArgs(WMEURMPT.updateListsFromManualScan, [{ type: 'managedArea' }])
       scanGroup.appendChild(elt)
     }
-    if (WMEURMPT.areaList.country.length === 0 && (WMEURMPT.ul >= 8 || WMEURMPT.me.isCountryManager())) {
+    if (!WMEURMPT.hideRank4Tip && WMEURMPT.areaList.country.length === 0 && (WMEURMPT.ul >= 8 || wmeSDK.State.getManagedCountries().length > 0)) {
       scanGroup.insertAdjacentHTML('beforeend', WMEURMPT.convertHtml('<br/><font color="#C00000">You are a rank 4+ editor. In the areas tab, you can select a country or a subset for state managers in the list and add it to your scan list!'))
     }
     for (let c = 0; c < WMEURMPT.areaList.country.length; c++) {
@@ -2209,10 +2206,10 @@ function WMEURMPT_Injected () {
           geometry = WMEURMPT.areaList[area.type][i].geometryGeoJSON.geometry
         }
         else if (typeof objArea.geometryWKT !== 'undefined' && objArea.geometryWKT !== null) {
-          geometry = W.userscripts.convertWktToGeoJSON(objArea.geometryWKT)
+          geometry = WMEURMPT.wazeUS.convertWktToGeoJSON(objArea.geometryWKT)
         }
         else if (typeof objArea.geometryOL !== 'undefined' && objArea.geometryOL !== null) {
-          geometry = W.userscripts.toGeoJSONGeometry(objArea.geometryOL)
+          geometry = WMEURMPT.wazeUS.toGeoJSONGeometry(objArea.geometryOL)
         }
         break
       }
@@ -2380,10 +2377,10 @@ function WMEURMPT_Injected () {
     WMEURMPT.statsCSV = ''
     const div = WMEURMPT.getId('urmpt-stats')
     WMEURMPT.removeChildElements(div)
-
+    try {
     let content = ''
     content = '<font style="font-size: larger; font-weight: bold;">Statistics</font><hr/>'
-    content += '<div style="display: flex;"><span style="margin: 5px; display: table;" >From: </span><input value="' + fromDate + '" type="text" id="urmpt-stat-from" size="9"/><span style="margin: 5px; display: table;" > to </span><input value="' + toDate + '" type="text" id="urmpt-stat-to" size="9"/><button id="urmpt-stat-refresh" style="display: table; width: 40px; padding: 0px;">OK</button></div><hr/>'
+    content += '<div style="display: flex; align-items: center; gap: 6px; margin: 5px 0;"><span>From:</span><input value="' + fromDate + '" type="text" id="urmpt-stat-from" size="9" style="height: 22px; box-sizing: border-box;"/><span>to</span><input value="' + toDate + '" type="text" id="urmpt-stat-to" size="9" style="height: 22px; box-sizing: border-box;"/><button id="urmpt-stat-refresh" style="height: 22px; padding: 0 10px; margin-left: -4px; box-sizing: border-box;">OK</button></div><hr/>'
     content += '<a id="urmpt-stat-export_csv" href="#">Export to CSV</a><hr/>'
 
     let dateFilteredURList = WMEURMPT.URList
@@ -2403,18 +2400,19 @@ function WMEURMPT_Injected () {
     content += WMEURMPT.computeStats(dateFilteredURList, dateFilteredMPList, fromDate, toDate)
     content += '<hr/>'
     content += 'You:<br/><br/>'
+    const myName = wmeSDK.State.getUserInfo().userName
     const closedURbyMe = dateFilteredURList.filter(function (value) {
-      return value.data.resolvedBy === WMEURMPT.me.getID()
+      return value.data.resolvedByName === myName
     }).length
     const closedMPbyMe = dateFilteredMPList.filter(function (value) {
-      return value.data.resolvedBy === WMEURMPT.me.getID()
+      return value.data.resolvedByName === myName
     }).length
     const niURbyMe = dateFilteredURList.filter(function (value) {
-      return value.data.resolvedBy === WMEURMPT.me.getID() && value.data.open === false && value.data.resolution === 1
+      return value.data.resolvedByName === myName && value.data.open === false && value.data.resolution === 1
     }).length
     const soURbyMe = closedURbyMe - niURbyMe
     const niMPbyMe = dateFilteredMPList.filter(function (value) {
-      return value.data.resolvedBy === WMEURMPT.me.getID() && value.data.open === false && value.data.resolution === 1
+      return value.data.resolvedByName === myName && value.data.open === false && value.data.resolution === 1
     }).length
     const soMPbyMe = closedMPbyMe - niMPbyMe
     content += 'URs closed: ' + closedURbyMe + ' (' + Math.round(closedURbyMe * 100 / dateFilteredURList.length) + '%)<br/>'
@@ -2425,7 +2423,6 @@ function WMEURMPT_Injected () {
     content += '&nbsp;&nbsp;Solved: ' + soMPbyMe + ' (' + Math.round(soMPbyMe * 100 / closedMPbyMe) + '%)<br/>'
     content += '<hr/>'
     content += 'Per area:<br/><br/>'
-    content += '<ul>'
     WMEURMPT.statsCSV += 'You' + NL
     WMEURMPT.statsCSV += 'UR;Count;Percent' + NL
     WMEURMPT.statsCSV += 'Closed;' + closedURbyMe + ';' + closedURbyMe * 100 / dateFilteredURList.length + NL
@@ -2442,7 +2439,7 @@ function WMEURMPT_Injected () {
     let fromMPList = dateFilteredMPList.filter(function (value) {
       return WMEURMPT.isInsideDriveArea(value.lonlat.lon, value.lonlat.lat)
     })
-    content += '<li>Your drive area<br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '</li>'
+    content += 'Your drive area:<br/><br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '<hr/>'
     if (WMEURMPT.uam) {
       WMEURMPT.statsCSV += 'Your managed area' + NL
       fromURList = dateFilteredURList.filter(function (value) {
@@ -2451,7 +2448,7 @@ function WMEURMPT_Injected () {
       fromMPList = dateFilteredMPList.filter(function (value) {
         return WMEURMPT.isInsideManagedArea(value.lonlat.lon, value.lonlat.lat)
       })
-      content += '<li>Your managed area<br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '</li>'
+      content += 'Your managed area:<br/><br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '<hr/>'
     }
     for (let a = 0; a < WMEURMPT.areaList.country.length; a++) {
       WMEURMPT.statsCSV += WMEURMPT.areaList.country[a].name + NL
@@ -2461,7 +2458,7 @@ function WMEURMPT_Injected () {
       fromMPList = dateFilteredMPList.filter(function (value) {
         return WMEURMPT.areaList.country[a].isInside(value.lonlat)
       })
-      content += '<li>' + WMEURMPT.areaList.country[a].name + '<br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '</li>'
+      content += WMEURMPT.areaList.country[a].name + ':<br/><br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '<hr/>'
     }
     for (let a = 0; a < WMEURMPT.areaList.custom.length; a++) {
       WMEURMPT.statsCSV += WMEURMPT.areaList.custom[a].name + NL
@@ -2471,15 +2468,16 @@ function WMEURMPT_Injected () {
       fromMPList = dateFilteredMPList.filter(function (value) {
         return WMEURMPT.areaList.custom[a].isInside(value.lonlat)
       })
-      content += '<li>' + WMEURMPT.areaList.custom[a].name + '<br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '</li>'
+      content += WMEURMPT.areaList.custom[a].name + ':<br/><br/>' + WMEURMPT.computeStats(fromURList, fromMPList, fromDate, toDate) + '<hr/>'
     }
-    content += '</ul>'
     div.innerHTML = WMEURMPT.convertHtml(content)
+    window.setTimeout(WMEURMPT.setupStatHandlers)
+    } finally {
     WMEURMPT.showPBInfo(false)
     pb.hide()
     pb.update(0)
     WMEURMPT.info()
-    window.setTimeout(WMEURMPT.setupStatHandlers)
+    }
   }
 
   WMEURMPT.setupStatHandlers = function () {
@@ -2497,7 +2495,7 @@ function WMEURMPT_Injected () {
   }
 
   WMEURMPT.exportStatsToCSV = function () {
-    this.setAttribute('download', 'URMPT_Stats_' + (new Date()).toISOString().substr(0, 10) + '_' + WMEURMPT.me.getUsername() + '.csv')
+    this.setAttribute('download', 'URMPT_Stats_' + (new Date()).toISOString().substr(0, 10) + '_' + wmeSDK.State.getUserInfo().userName + '.csv')
     this.href = 'data:application/octet-stream;charset=utf-8;base64,' + btoa(WMEURMPT.statsCSV)
   }
 
@@ -2732,7 +2730,7 @@ function WMEURMPT_Injected () {
 
       // Create Title & Legend //
       const titleSection = WMEURMPT.createElement('p', 'urt-main-title')
-      titleSection.style.paddingTop = '0px'
+      titleSection.style.padding = '6px 0 4px'
       titleSection.style.marginTop = '-15px'
       titleSection.style.textIndent = '8px'
       content = `
@@ -2744,15 +2742,15 @@ function WMEURMPT_Injected () {
       `
 
       if (WMEURMPT.displayLegend) {
-        content += '<div id="urt-legend" ><table class="urt-table"><tr><td class="urt-bg-selected">Last visited</td><td>Visited</td></tr><tr><td class="urt-bg-ifollow">I follow</td><td class="urt-bg-highlighted">Never visited</td></tr></table></div>'
+        content += '<div id="urt-legend" style="margin-top: 4px; margin-left: 6px;"><table class="urt-table"><tr><td class="urt-bg-selected">Last visited</td><td>Visited</td></tr><tr><td class="urt-bg-ifollow">I follow</td><td class="urt-bg-highlighted">Never visited</td></tr></table></div>'
       }
       titleSection.innerHTML = WMEURMPT.convertHtml(content)
       addon.append(titleSection)
 
       // Create Quick Options //
       const quickOptions = WMEURMPT.createElement('span', 'urmpt-qoptions')
-      content = '<font style="font-size: smaller; font-weight: 600;">Quick options:</font><hr style="margin: 0px;" />'
-      content += '<table style="border: 0px; width: 100%;"><tr>'
+      content = '<font style="font-size: smaller; font-weight: 600; margin-left: 10px;">Quick options:</font><hr style="margin: 0px; width: 100%; box-sizing: border-box;" />'
+      content += '<table style="border: 0px; width: 80%; margin: 0 auto;"><tr>'
       content += '<td style="width: 50%;">'
       content += '<a href="#" id="urmpt-donoff"><img class="urt-chkbox" src="data:image/png;base64,' + (WMEURMPT.isComputeDistances ? WMEURMPT.icon_checked : WMEURMPT.icon_unchecked) + '" /></a>Distances<br/>'
       content += '<a href="#" id="urmpt-asonoff"><img class="urt-chkbox" src="data:image/png;base64,' + (WMEURMPT.isAutoScan ? WMEURMPT.icon_checked : WMEURMPT.icon_unchecked) + '" /></a>Auto scan'
@@ -2776,13 +2774,13 @@ function WMEURMPT_Injected () {
       // Create tab menu bar
       const urmpTabs = WMEURMPT.createElement('ul', 'urmp-tabs')
       urmpTabs.className = 'nav nav-tabs'
-      content = '<li class="active" style="width: 13.75%; text-align: center; height: 30px;"><a id="urmp-tabstitle-ur" style="height: 30px;" href="#urmp-tabs-ur" data-toggle="tab">UR</a></li>'
-      content += '<li class="" style="width: 13.75%; text-align: center; height: 30px;"><a id="urmp-tabstitle-mp" style="height: 30px;" href="#urmp-tabs-mp" data-toggle="tab">MP</a></li>'
-      content += '<li class="" style="width: 13.75%; text-align: center; height: 30px;"><a id="urmp-tabstitle-mc" style="height: 30px;" href="#urmp-tabs-mc" data-toggle="tab">MC</a></li>'
-      content += '<li class="" style="width: 13.75%; text-align: center; height: 30px;"><a id="urmp-tabstitle-pur" style="height: 30px;" href="#urmp-tabs-pur" data-toggle="tab">PUR</a></li>'
-      content += '<li class="" style="width: 13.75%; text-align: center; height: 30px;"><a class="fa fa-bar-chart icon-bar-chart" id="urmp-tabstitle-stat" style="height: 30px;" href="#urmp-tabs-os" data-toggle="tab"></a></li>'
-      content += '<li class="" style="width: 13.75%; text-align: center; height: 30px;"><a class="w-icon-2x w-icon w-icon-pencil" style="font-size: 1.5em; height: 30px;" href="#urmp-tabs-areas" data-toggle="tab"></a></li>'
-      content += '<li class="" style="width: 13.75%; text-align: center; height: 30px;"><a class="w-icon-2x w-icon w-icon-settings" style="font-size: 1.5em; height: 30px;" href="#urmp-tabs-settings" data-toggle="tab"></a></li>'
+      content = '<li class="active" style="height: 30px;"><a id="urmp-tabstitle-ur" style="height: 30px;" href="#urmp-tabs-ur" data-toggle="tab">UR</a></li>'
+      content += '<li class="" style="height: 30px;"><a id="urmp-tabstitle-mp" style="height: 30px;" href="#urmp-tabs-mp" data-toggle="tab">MP</a></li>'
+      content += '<li class="" style="height: 30px;"><a id="urmp-tabstitle-mc" style="height: 30px;" href="#urmp-tabs-mc" data-toggle="tab">MC</a></li>'
+      content += '<li class="" style="height: 30px;"><a id="urmp-tabstitle-pur" style="height: 30px;" href="#urmp-tabs-pur" data-toggle="tab">PUR</a></li>'
+      content += '<li class="" style="height: 30px;"><a class="fa fa-bar-chart icon-bar-chart" id="urmp-tabstitle-stat" style="height: 30px;" href="#urmp-tabs-os" data-toggle="tab"></a></li>'
+      content += '<li class="" style="height: 30px;"><a class="w-icon w-icon-pencil" style="font-size: 1em; height: 30px;" href="#urmp-tabs-areas" data-toggle="tab"></a></li>'
+      content += '<li class="" style="height: 30px;"><a class="w-icon w-icon-settings" style="font-size: 1em; height: 30px;" href="#urmp-tabs-settings" data-toggle="tab"></a></li>'
       urmpTabs.innerHTML = WMEURMPT.convertHtml(content)
       addon.appendChild(urmpTabs)
       window.setTimeout(WMEURMPT.connectURTabHandler)
@@ -2803,7 +2801,7 @@ function WMEURMPT_Injected () {
       const urTabPane = WMEURMPT.createElement('section', 'urmp-tabs-ur')
       urTabPane.className = 'tab-pane active'
       urTabPane.style.paddingLeft = '0px'
-      urTabPane.style.paddingRight = '0px'
+      urTabPane.style.paddingRight = '35px'
       urmpTabContent.appendChild(urTabPane)
       const urMenu = WMEURMPT.createElement('center')
       urTabPane.appendChild(urMenu)
@@ -3069,6 +3067,7 @@ function WMEURMPT_Injected () {
       osTabPane.className = 'tab-pane'
       osTabPane.style.paddingLeft = '0px'
       osTabPane.style.paddingRight = '40px'
+      osTabPane.style.paddingTop = '10px'
       urmpTabContent.appendChild(osTabPane)
       const divStats = WMEURMPT.createElement('div','urmpt-stats')
       osTabPane.appendChild(divStats)
@@ -3080,7 +3079,7 @@ function WMEURMPT_Injected () {
       areasTabPane.style.paddingLeft = '0px'
       areasTabPane.style.paddingRight = '40px'
       urmpTabContent.appendChild(areasTabPane)
-      if (WMEURMPT.ul >= 8 || WMEURMPT.me.isCountryManager()) {
+      if (WMEURMPT.ul >= 8 || wmeSDK.State.getManagedCountries().length > 0) {
         const divCM = WMEURMPT.createElement('div')
         divCM.innerHTML = WMEURMPT.convertHtml('Add country(ies) or subset(s) to scan list.<br/>')
         const divInput = WMEURMPT.createElement('div')
@@ -3208,8 +3207,11 @@ function WMEURMPT_Injected () {
       disableScrollingSpan.innerHTML = WMEURMPT.convertHtml('<input type="checkbox" id="urmpt-setting-disablescrolling" ' + (WMEURMPT.disableScrolling ? 'checked ' : '') + '/> Disable text scrolling in tables<br>')
       settingsTabPane.appendChild(disableScrollingSpan)
       const keepBlacklist = WMEURMPT.createElement('span')
-      keepBlacklist.innerHTML = WMEURMPT.convertHtml('<input type="checkbox" id="urmpt-setting-keepblacklist" ' + (WMEURMPT.keepBlacklist ? 'checked ' : '') + '/> Keep blacklist state on clear')
+      keepBlacklist.innerHTML = WMEURMPT.convertHtml('<input type="checkbox" id="urmpt-setting-keepblacklist" ' + (WMEURMPT.keepBlacklist ? 'checked ' : '') + '/> Keep blacklist state on clear<br>')
       settingsTabPane.appendChild(keepBlacklist)
+      const hideRank4TipSpan = WMEURMPT.createElement('span')
+      hideRank4TipSpan.innerHTML = WMEURMPT.convertHtml('<input type="checkbox" id="urmpt-setting-hiderank4tip" ' + (WMEURMPT.hideRank4Tip ? 'checked ' : '') + '/> Hide rank 4+ editor scan tip')
+      settingsTabPane.appendChild(hideRank4TipSpan)
       window.setTimeout(WMEURMPT.setupCAEvents)
       window.setTimeout(WMEURMPT.updateScanGroup)
 
@@ -3495,6 +3497,11 @@ function WMEURMPT_Injected () {
 
         WMEURMPT.saveOptions()
       })
+      WMEURMPT.getId('urmpt-setting-hiderank4tip').addEventListener('change', function (e) {
+        WMEURMPT.hideRank4Tip = e.target.checked
+        WMEURMPT.saveOptions()
+        WMEURMPT.updateScanGroup()
+      })
       // End of Settings Tab //
 
       // Setup Stylesheet //
@@ -3505,7 +3512,7 @@ function WMEURMPT_Injected () {
       css += '.urt-table tr { border: 1px solid #3d3d3d; }'
       css += '.urt-table tr td { border: 1px solid #3d3d3d; font-size: smaller; }'
       css += '.urt-table thead { border: 2px solid #3d3d3d; font-size: bigger; text-align: center; background-color: #93c4d3;}'
-      css += '.urt-table-head-icon { height: 32px; vertical-align: middle; display: table-cell; }'
+      css += '.urt-table-head-icon { height: 32px; vertical-align: middle; display: table-cell; white-space: nowrap; }'
       css += '.urt-bg-pair { background-color: #93c4d3; }'
       css += '.urt-bg-highlighted { background-color: #c9e1e9; }'
       css += '.urt-bg-selected { background-color: #42FF9c; }'
@@ -3526,7 +3533,11 @@ function WMEURMPT_Injected () {
       css += '.urt-progressBarFG { float: left; position: relative; bottom: 22px; height: 0px; text-align: center; width: 100% }'
       css += '#urt-info { margin: 5px; }'
       css += '.urt-blacklist { background: transparent url(data:image/png;base64,' + WMEURMPT.icon_blacklist + ') center top; background-size: 16px 16px; background-repeat: no-repeat; } '
-      css += '#urmpt-qoptions { display: block; width: 100%; border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; border: 1px solid #dddddd; }'
+      css += '#urmp-tabs { display: flex; width: calc(100% - 26px) !important; padding-left: 0; padding-right: 0; margin: 0 20px 0 6px; border-radius: 12px; overflow: hidden; border: 1px solid #dddddd; }'
+      css += '#urmp-tabs > li { display: block; flex: 1 1 0; min-width: 0; text-align: center; }'
+      css += '#urmp-tabs > li > a { display: block; padding: 5px 0; margin-right: 0; text-align: center; overflow: hidden; white-space: nowrap; }'
+      css += '#urmp-tabs > li.active > a, #urmp-tabs > li.active > a:hover, #urmp-tabs > li.active > a:focus { border-radius: 10px; border-bottom-color: #ddd; }'
+      css += '#urmpt-qoptions { display: block; margin: 0 20px 0 6px; border-radius: 12px; border: 1px solid #dddddd; }'
       css += '.urt-chkbox { width: 16px; height: 16px; margin-top: -5px; }'
       cssElt.innerHTML = WMEURMPT.convertHtml(css)
       document.body.appendChild(cssElt)
@@ -3543,6 +3554,7 @@ function WMEURMPT_Injected () {
       } else {
         WMEURMPT.disable()
       }
+      WMEURMPT.connectStatHandler()
 
     })
 
@@ -3576,14 +3588,16 @@ function WMEURMPT_Injected () {
   }
 
   WMEURMPT.getTLArea = function () {
-    const xy = WMEURMPT.wazeMap.getLonLatFromPixel({ x: 0, y: 0 })
+    const bbox = wmeSDK.Map.getMapExtent()
+    const xy = { lon: bbox[0], lat: bbox[3] }
     WMEURMPT.log('get TL', xy)
     WMEURMPT.getId('urmpt-areas-tl-lon').value = xy.lon
     WMEURMPT.getId('urmpt-areas-tl-lat').value = xy.lat
   }
 
   WMEURMPT.getBRArea = function () {
-    const xy = WMEURMPT.wazeMap.getLonLatFromPixel({ x: WMEURMPT.wazeMap.getSize().w, y: WMEURMPT.wazeMap.getSize().h })
+    const bbox = wmeSDK.Map.getMapExtent()
+    const xy = { lon: bbox[2], lat: bbox[1] }
     WMEURMPT.log('get BR', xy)
     WMEURMPT.getId('urmpt-areas-br-lon').value = xy.lon
     WMEURMPT.getId('urmpt-areas-br-lat').value = xy.lat
@@ -3629,7 +3643,7 @@ function WMEURMPT_Injected () {
   WMEURMPT.enable = function () {
     WMEURMPT.registerEvents()
     WMEURMPT.getId('urt-a-scanGroup').style.display = 'inline'
-    WMEURMPT.getId('urmp-tabs').style.display = 'block'
+    WMEURMPT.getId('urmp-tabs').style.display = ''
     WMEURMPT.getId('urmpt-tab-content').style.display = 'block'
     WMEURMPT.getId('urmpt-qoptions').style.display = 'block'
     WMEURMPT.updateIHMFromURList()
@@ -3667,12 +3681,12 @@ function WMEURMPT_Injected () {
         eventHandler: WMEURMPT.newDataAvailableStartsViaAutoScan
       })
     } else {
-      if (wmeSDK.Events.eventBus.handlers.has('wme-data-model-objects-added')) {
+      try {
         wmeSDK.Events.off({
           eventName: 'wme-data-model-objects-added',
           eventHandler: WMEURMPT.newDataAvailableStartsViaAutoScan
         })
-      }
+      } catch (e) { /* handler was not registered */ }
     }
   }
 
@@ -4728,7 +4742,7 @@ function WMEURMPT_Injected () {
         comments += WMEURMPT.URList[i].data.session.comments[c].userName + ' (' + (new Date(WMEURMPT.URList[i].data.session.comments[c].createdOn)).toLocaleString() + '):' + NL
         comments += WMEURMPT.URList[i].data.session.comments[c].text + NL + NL
         lastCommentDays = WMEURMPT.getDuration(WMEURMPT.URList[i].data.session.comments[c].createdOn)
-        if (c === WMEURMPT.URList[i].data.session.comments.length - 1 && WMEURMPT.URList[i].data.session.comments[c].userName === WMEURMPT.me.getUsername()) {
+        if (c === WMEURMPT.URList[i].data.session.comments.length - 1 && WMEURMPT.URList[i].data.session.comments[c].userName === wmeSDK.State.getUserInfo().userName) {
           WMEURMPT.URList[i].lastVisitCommentsCount = WMEURMPT.URList[i].data.session.comments.length
         }
       }
@@ -5075,7 +5089,7 @@ function WMEURMPT_Injected () {
           let text = c.userName + ' (' + (new Date(c.createdOn)).toLocaleString() + '):' + NL
           text += c.text
           conversationArray.push(text)
-          if (j === WMEURMPT.MCList[i].data.conversation.length - 1 && c.userName === WMEURMPT.me.getUsername()) {
+          if (j === WMEURMPT.MCList[i].data.conversation.length - 1 && c.userName === wmeSDK.State.getUserInfo().userName) {
             WMEURMPT.MCList[i].lastVisitCommentsCount = WMEURMPT.MCList[i].data.conversation.length
           }
         })
@@ -5768,7 +5782,7 @@ function WMEURMPT_Injected () {
       }
       WMEURMPT.newDataAvailableStarts(
         {
-          dataModelName: 'mapUpdateRequets',
+          dataModelName: 'mapUpdateRequests',
           objectIds: [URId.URId]
 
         }
@@ -5787,7 +5801,7 @@ function WMEURMPT_Injected () {
       return
     }
     //const mp = wmeSDK.DataModel.MapProblems.getById({ mapProblemId: MPId.MPId })
-    const mp = W.model.mapProblems.getObjectById(MPId.MPId)
+    const mp = WMEURMPT.wazeModel.mapProblems.getObjectById(MPId.MPId)
     WMEURMPT.logDebug('mp :', mp)
     if (mp !== null) {
         WMEURMPT.wazePC.showProblem(mp, { showNext: false })
@@ -5859,7 +5873,7 @@ function WMEURMPT_Injected () {
       WMEURMPT.PURVisited(PURId.PURId)
       WMEURMPT.currentPURID = PURId.PURId
       WMEURMPT.newDataAvailableStarts(
-        {dataModelname: 'venues', objectIds: [PURId.PURId]}
+        {dataModelName: 'venues', objectIds: [PURId.PURId]}
       )
 
       wmeSDK.Editing.setSelection({
@@ -5936,10 +5950,22 @@ function WMEURMPT_Injected () {
         dataObj.objectIds.forEach( urID => {
           WMEURMPT.log('scan only selected: UR: ' + urID)
           if (urID != null) {
-            const theUR = WMEURMPT.getURFromId(urID)
+            let theUR = WMEURMPT.getURFromId(urID)
             if (theUR != null) {
               theUR.refreshFromWMEData()
               WMEURMPT.updateIHMFromURList()
+            } else if (WMEURMPT.isAutoScan && WMEURMPT.scanUR) {
+              const sdkUR = wmeSDK.DataModel.MapUpdateRequests.getById({ mapUpdateRequestId: urID })
+              if (sdkUR) {
+                const URxy = turf.point(sdkUR.geometry.coordinates)
+                if (WMEURMPT.inScreenUpdatableArea(URxy) || WMEURMPT.isInAreas(URxy)) {
+                  theUR = new WMEURMPT.URT_UR(sdkUR.id, sdkUR.geometry.coordinates[0], sdkUR.geometry.coordinates[1])
+                  theUR.refreshFromWMEData()
+                  WMEURMPT.URList.push(theUR)
+                  WMEURMPT.URMap = WMEURMPT.listToObject(WMEURMPT.URList)
+                  WMEURMPT.updateIHMFromURList()
+                }
+              }
             }
           }
         })
@@ -6182,7 +6208,7 @@ function WMEURMPT_Injected () {
     if (e.type === 'mapUpdateRequest') {
       id = e.attributes.id
     } else if (typeof this.tagName !== 'undefined' && this.tagName === 'image') {
-      const mod = W.userscripts.getDataModelByFeatureElement(this)
+      const mod = WMEURMPT.wazeUS.getDataModelByFeatureElement(this)
       id = mod.attributes.id
     }
     if (id > 0) {
@@ -6271,7 +6297,7 @@ function WMEURMPT_Injected () {
   WMEURMPT.conversationSent = function () {
     const ur = WMEURMPT.getURFromId(WMEURMPT.currentURID)
     if (ur !== null) {
-      WMEURMPT.log('update Comment and refresh...')
+      WMEURMPT.log('conversationSent[' + WMEURMPT.currentURID + ']: commentsBefore=' + (ur.data.session?.comments?.length ?? 0) + ' lastVisitCount=' + ur.lastVisitCommentsCount)
       ur.refreshFromWMEData(true)
       ur.lastVisitCommentsCount = ur.data.session.comments.length
       WMEURMPT.updateIHMFromURList()
@@ -6648,7 +6674,7 @@ function WMEURMPT_Injected () {
         const userID = ur.data.session.comments[c].userID
         let userName = 'Unknown'
         if (userID === WMEURMPT.me.getID()) {
-          userName = WMEURMPT.me.getUsername()
+          userName = wmeSDK.State.getUserInfo().userName
           if (c === ur.data.session.comments.length - 1) {
             ur.lastVisitCommentsCount = ur.data.session.comments.length
           }
@@ -6749,7 +6775,6 @@ function WMEURMPT_Injected () {
       }
       if (Object.prototype.hasOwnProperty.call(mc.data, 'conversation')) {
         mc.data.conversation.forEach(function (c, i) {
-          // what's the SDK version to fetch the user id now??? //
           if (c.userID === WMEURMPT.me.getID()) {
             if (i === mc.data.conversation.length - 1) {
               mc.lastVisitCommentsCount = mc.data.conversation.length
@@ -7289,24 +7314,34 @@ function WMEURMPT_Injected () {
 
       const oldData = this.data
       const commentLength = updateReqDetails.comments.length
+      WMEURMPT.log('refreshFromWMEData[' + this.id + ']: SDK returned ' + commentLength + ' comments, had ' + (oldData.session?.comments?.length ?? 0))
 
       this.data = {}
-      this.data.description = (typeof oldData.description !== 'undefined' ? oldData.description : '') // Not in SDK
+      this.data.description = theUR.description ?? null
       this.data.driveDate = theUR.reportedOn
       this.data.hasComments = (commentLength > 0 ? true : false)
       this.data.open = theUR.isOpen
       this.data.resolvedOn = theUR.resolvedOn
-      // this.data.resolvedBy = theUR.attributes.resolvedBy // not in SDK
+      this.data.resolvedBy = theUR.resolvedBy ?? null
+      this.data.resolvedByName = theUR.resolvedBy ?? 'Unknown'
       this.data.resolution = theUR.resolutionState
       this.data.type = WMEURMPT.mapUpdateType(theUR.updateRequestType)
       this.data.updatedOn = (typeof oldData.updatedOn !== 'undefined' ? oldData.updatedOn : null) // Not in SDK
       this.data.updatedBy = (typeof oldData.updatedBy !== 'undefined' ? oldData.updatedBy : null) // Not in SDK
       this.data.session = {}
-      this.data.session.comments = updateReqDetails.comments
-
-      if (commentLength > 0) {
-        this.data.updatedBy = updateReqDetails.comments[commentLength - 1].userName
-        this.data.updatedOn = updateReqDetails.comments[commentLength - 1].createdOn
+      const hadComments = oldData.session?.comments?.length > 0
+      if (commentLength > 0 || !hadComments) {
+        this.data.session.comments = updateReqDetails.comments
+        if (commentLength > 0) {
+          this.data.updatedBy = updateReqDetails.comments[commentLength - 1].userName
+          this.data.updatedOn = updateReqDetails.comments[commentLength - 1].createdOn
+        }
+      } else {
+        // SDK returned empty comments but we had data — UR was reloaded into view without
+        // details being fetched yet. Preserve existing comment data to avoid counter reset.
+        this.data.session.comments = oldData.session.comments
+        this.data.updatedBy = oldData.updatedBy
+        this.data.updatedOn = oldData.updatedOn
       }
 
       this.clean()
@@ -7352,8 +7387,8 @@ function WMEURMPT_Injected () {
                       break
                     }
                   }
-                  if (userID === WMEURMPT.loginManager.user.getID()) {
-                    userName = WMEURMPT.loginManager.user.getUsername()
+                  if (userID === WMEURMPT.me.getID()) {
+                    userName = wmeSDK.State.getUserInfo().userName
                   }
                 }
                 this.data.session.comments[c].userName = userName
@@ -7606,7 +7641,7 @@ function WMEURMPT_Injected () {
               if (Object.prototype.hasOwnProperty.call(this.data, 'conversation')) {
                 this.data.conversation.forEach(function (c, j) {
                   if (c.userID === WMEURMPT.me.getID()) {
-                    c.userName = WMEURMPT.me.getUsername()
+                    c.userName = wmeSDK.State.getUserInfo().userName
                     if (j === this.data.conversation.length - 1) {
                       this.lastVisitCommentsCount = this.data.conversation.length
                     }
@@ -7913,7 +7948,7 @@ function WMEURMPT_Injected () {
         return turf.booleanPointInPolygon(point, this.geometryGeoJSON)
       }
       else if (typeof this.geometryWKT !== 'undefined' && this.geometryWKT !== 'null' && this.geometryWKT !== '') {
-        this.geometryGeoJSON = turf.multiPolygon(W.userscripts.convertWktToGeoJSON(this.geometryWKT).coordinates)
+        this.geometryGeoJSON = turf.multiPolygon(WMEURMPT.wazeUS.convertWktToGeoJSON(this.geometryWKT).coordinates)
         return turf.booleanPointInPolygon(point, this.geometryGeoJSON)
       }
       return false
@@ -7971,7 +8006,8 @@ function WMEURMPT_Injected () {
       MCAgeColIsLastComment: WMEURMPT.MCAgeColIsLastComment,
       disableScrolling: WMEURMPT.disableScrolling,
       purInvertFilter: WMEURMPT.purInvertFilter,
-      urtInvertFilter: WMEURMPT.urtInvertFilter
+      urtInvertFilter: WMEURMPT.urtInvertFilter,
+      hideRank4Tip: WMEURMPT.hideRank4Tip
     }
     WMEURMPT.log('save options: ', options)
     // eslint-disable-next-line no-undef
@@ -8039,9 +8075,9 @@ function WMEURMPT_Injected () {
       WMEURMPT.currentMPFilter = typeof options.filterMP === 'undefined' ? WMEURMPT.MPFilterList.hideClosed + WMEURMPT.MPFilterList.hideBlacklisted : options.filterMP
       WMEURMPT.currentMCFilter = typeof options.filterMC === 'undefined' ? WMEURMPT.MCFilterList.hideBlacklisted : options.filterMC
       WMEURMPT.currentPURFilter = typeof options.filterPUR === 'undefined' ? WMEURMPT.PURFilterList.hideBlacklisted : options.filterPUR
-      WMEURMPT.currentURKeyWord = typeof options.filterURKeyword === 'undefined' ? WMEURMPT.loginManager.user.getUsername() : options.filterURKeyword
-      WMEURMPT.currentMCKeyWord = typeof options.filterMCKeyword === 'undefined' ? WMEURMPT.loginManager.user.getUsername() : options.filterMCKeyword
-      WMEURMPT.currentPURKeyWord = typeof options.filterPURKeyword === 'undefined' ? WMEURMPT.loginManager.user.getUsername() : options.filterPURKeyword
+      WMEURMPT.currentURKeyWord = typeof options.filterURKeyword === 'undefined' ? wmeSDK.State.getUserInfo().userName : options.filterURKeyword
+      WMEURMPT.currentMCKeyWord = typeof options.filterMCKeyword === 'undefined' ? wmeSDK.State.getUserInfo().userName : options.filterMCKeyword
+      WMEURMPT.currentPURKeyWord = typeof options.filterPURKeyword === 'undefined' ? wmeSDK.State.getUserInfo().userName : options.filterPURKeyword
       WMEURMPT.currentURLimitTo = typeof options.filterURLimitTo === 'undefined' ? 100 : options.filterURLimitTo
       WMEURMPT.currentMPLimitTo = typeof options.filterMPLimitTo === 'undefined' ? 100 : options.filterMPLimitTo
       WMEURMPT.currentMCLimitTo = typeof options.filterMCLimitTo === 'undefined' ? 100 : options.filterMCLimitTo
@@ -8077,6 +8113,7 @@ function WMEURMPT_Injected () {
       WMEURMPT.purInvertFilter = typeof options.purInvertFilter === 'undefined' ? WMEURMPT.purInvertFilter : options.purInvertFilter
       WMEURMPT.urtInvertFilter = typeof options.urtInvertFilter === 'undefined' ? WMEURMPT.urtInvertFilter : options.urtInvertFilter
       WMEURMPT.keepBlacklist = typeof options.keepBlacklist === 'undefined' ? WMEURMPT.keepBlacklist : options.keepBlacklist
+      WMEURMPT.hideRank4Tip = typeof options.hideRank4Tip === 'undefined' ? false : options.hideRank4Tip
       WMEURMPT.URBlacklist = typeof options.URBlacklist === 'undefined' ? WMEURMPT.URBlacklist : options.URBlacklist
       WMEURMPT.MPBlacklist = typeof options.MPBlacklist === 'undefined' ? WMEURMPT.MPBlacklist : options.MPBlacklist
       WMEURMPT.MCBlacklist = typeof options.MCBlacklist === 'undefined' ? WMEURMPT.MCBlacklist : options.MCBlacklist
@@ -8180,7 +8217,7 @@ function WMEURMPT_Injected () {
 
   WMEURMPT.load = function () {
     try {
-      WMEURMPT.dictionary['"' + WMEURMPT.me.getUsername() + '"'] = '~Z'
+      WMEURMPT.dictionary['"' + wmeSDK.State.getUserInfo().userName + '"'] = '~Z'
 
       GMStorageHelper.load('WMEURMPTracking_options', WMEURMPT.optionsLoaded)
       GMStorageHelper.load('WMEURMPTracking_URList', WMEURMPT.urlistLoaded)
@@ -8202,7 +8239,7 @@ function WMEURMPT_Injected () {
     this.pannel_elt.style.width = w
     this.pannelTrigger_elt = WMEURMPT.createElement('div', 'popup-pannel-trigger-' + name)
     this.pannelTrigger_elt.className = 'popup-pannel-trigger-class-' + name
-    this.pannelTrigger_elt.onclick = WMEURMPT.getFunctionWithArgs(triggerMouseOver, [name, w, h])
+    this.pannelTrigger_elt.onclick = WMEURMPT.getFunctionWithArgs(togglePanel, [name, w, h])
     this.pannelTrigger_elt.style.backgroundColor = bgcolor
     this.pannelContents_elt = WMEURMPT.createElement('div', 'popup-pannel-contents-' + name)
     this.pannelContents_elt.className = 'popup-pannel-contents-closed-class-' + name
@@ -8212,41 +8249,23 @@ function WMEURMPT_Injected () {
     this.installInside = installInside
     this.setTriggerInnerHTML = setTriggerInnerHTML
     this.setContentsInnerHTML = setContentsInnerHTML
-    function triggerMouseOver (name, w, h) {
+    function togglePanel (name, w, h) {
       const elt = document.getElementById('popup-pannel-contents-' + name)
-      elt.style.width = w
-      elt.style.height = h
-      elt.className = 'popup-pannel-contents-open-class-' + name
       const triggerElt = document.getElementById('popup-pannel-trigger-' + name)
-      triggerElt.style.borderBottomRightRadius = '0px'
-      triggerElt.style.borderBottomLeftRadius = '0px'
-      window.setTimeout(function () {
-        document.getElementById('popup-pannel-contents-' + name).onmouseleave = function (e) {
-          const elementMouseIsOver = document.elementFromPoint(e.clientX, e.clientY)
-          if (WMEURMPT.isDescendant(this, elementMouseIsOver)) {
-            return
-          }
-          panelMouseLeave(name)
-        }
-        document.getElementById('popup-pannel-' + name).onmouseleave = function (e) {
-          const elementMouseIsOver = document.elementFromPoint(e.clientX, e.clientY)
-          if (WMEURMPT.isDescendant(this, elementMouseIsOver)) {
-            return
-          }
-          panelMouseLeave(name)
-        }
-      }, 100)
-    }
-    function panelMouseLeave (name) {
-      const elt = document.getElementById('popup-pannel-contents-' + name)
-      elt.style.width = '0px'
-      elt.style.height = '0px'
-      elt.className = 'popup-pannel-contents-closed-class-' + name
-      const triggerElt = document.getElementById('popup-pannel-trigger-' + name)
-      triggerElt.style.borderBottomRightRadius = '5px'
-      triggerElt.style.borderBottomLeftRadius = '5px'
-      document.getElementById('popup-pannel-contents-' + name).onmouseleave = null
-      document.getElementById('popup-pannel-' + name).onmouseleave = null
+      const isOpen = elt.className === 'popup-pannel-contents-open-class-' + name
+      if (isOpen) {
+        elt.style.width = '0px'
+        elt.style.height = '0px'
+        elt.className = 'popup-pannel-contents-closed-class-' + name
+        triggerElt.style.borderBottomRightRadius = '5px'
+        triggerElt.style.borderBottomLeftRadius = '5px'
+      } else {
+        elt.style.width = w
+        elt.style.height = h
+        elt.className = 'popup-pannel-contents-open-class-' + name
+        triggerElt.style.borderBottomRightRadius = '0px'
+        triggerElt.style.borderBottomLeftRadius = '0px'
+      }
     }
     function setTriggerInnerHTML (htmltext) {
       this.pannelTrigger_elt.innerHTML = WMEURMPT.convertHtml(htmltext)


### PR DESCRIPTION
## Summary
- Migrate from legacy `W.*` globals to the WME SDK (`wmeSDK`) for events, data model tracking, and user info.
- Add hideRank4Tip setting and fix personal stats calculation.
- Fix numeric user-ID comparisons broken by the SDK migration (`wmeSDK.State.getUserInfo()` has no numeric `.id`); restored to `WMEURMPT.me.getID()`, matching the existing convention used elsewhere in this script.
- Fix sidebar UI: quick-options box and UR/MP/MC/PUR nav tabs no longer overflow under the scrollbar, get a consistent centered/rounded style, and align with the panel title/legend.
- Fix the Filters popup panel closing itself immediately after opening (was relying on fragile hover/mouseleave detection); it now toggles open/closed on click.
- Restructure the Statistics tab's Per-area section to match the General/You layout instead of a bulleted list.

This replaces #31 (closed) with a single clean commit on top of current main.

## Test plan
- [ ] Verify UR/MP/MC/PUR tracking still loads and scans correctly under the SDK
- [ ] Verify Filters panel opens/stays open/closes on click for all four tabs
- [ ] Verify Statistics tab renders General/You/Per-area sections correctly
- [ ] Verify sidebar nav tabs and quick-options box render without overflow